### PR TITLE
Add support for text wrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ conversion("<table><tr><td>cell value</td></tr></table>" }, function(err, stream
 - `font-size` - font size
 - `colspan` - numeric value that merges current column with columns to the right
 - `rowspan` - numeric value that merges current row with rows below.  
+- `overflow` - the excel cell will have text wrap enabled if this is set to scoll.
 
 
 ## Options

--- a/lib/conversion.js
+++ b/lib/conversion.js
@@ -124,6 +124,8 @@ function tableToXlsx(table, id, cb) {
             sheet1.set(tmpCol, curr_row + 1, cell.value ? cell.value.replace(/&(?!amp;)/g, '&').replace(/&amp;(?!amp;)/g, '&') : cell.value);
             sheet1.align(tmpCol, curr_row + 1, cell.horizontalAlign);
             sheet1.valign(tmpCol, curr_row + 1, cell.verticalAlign === "middle" ? "center" : cell.verticalAlign);
+			
+            sheet1.wrap(curr_col + 1, curr_row + 1, cell.wrapText == "scroll");
 
             if (isColorDefined(cell.backgroundColor)) {
                 sheet1.fill(tmpCol, curr_row + 1, {

--- a/lib/scripts/conversionScriptPart.js
+++ b/lib/scripts/conversionScriptPart.js
@@ -21,6 +21,7 @@ page.evaluate(function() {
                 fontWeight: cs.getPropertyValue('font-weight'),
                 verticalAlign: cs.getPropertyValue('vertical-align'),
                 horizontalAlign: cs.getPropertyValue('text-align'),
+                wrapText: cs.getPropertyValue('overflow'),
                 width: cell.clientWidth,
                 height: cell.clientHeight,
                 rowspan: cell.rowSpan,


### PR DESCRIPTION
Uses the html overflow attribute as scrolling the excess text in a cell is comparable to allowing multiple lines (i.e. excel text-wrapping).